### PR TITLE
docs: Fix the wrong npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A TypeScript [type predicates](https://www.typescriptlang.org/docs/handbook/2/na
 ## How to use
 
 ```bash
-npm i -D generate-type-guards
+npm i -D type-predicate-generator
 npx type-predicate-generator --unitTests src/types.ts
 ```
 


### PR DESCRIPTION
The npm package `generate-type-guards` doesn't exist.

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/generate-type-guards - Not found
npm error 404
npm error 404  'generate-type-guards@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```